### PR TITLE
Fix slope2 calculation in getAngleTwoPoints

### DIFF
--- a/lib/utils/camera/pose_detector.dart
+++ b/lib/utils/camera/pose_detector.dart
@@ -235,6 +235,7 @@ double getSlope(List<double> pointA, List<double> pointB) {
 double getAngleTwoPoints(List<double> line1A, List<double> line1B,
     List<double> line2A, List<double> line2B) {
   final slope1 = getSlope(line1A, line1B);
+  // Slope of the second line
   final slope2 = getSlope(line2A, line2B);
   if (slope1 * slope2 == -1) {
     return 90.00;

--- a/lib/utils/camera/pose_detector.dart
+++ b/lib/utils/camera/pose_detector.dart
@@ -235,7 +235,7 @@ double getSlope(List<double> pointA, List<double> pointB) {
 double getAngleTwoPoints(List<double> line1A, List<double> line1B,
     List<double> line2A, List<double> line2B) {
   final slope1 = getSlope(line1A, line1B);
-  final slope2 = getSlope(line1A, line1B);
+  final slope2 = getSlope(line2A, line2B);
   if (slope1 * slope2 == -1) {
     return 90.00;
   }


### PR DESCRIPTION
## Summary
- correct slope2 calculation by calling `getSlope` with the second pair of points

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f5b6399483219fb38d3fe5d550cc